### PR TITLE
Enable components search in package config mode

### DIFF
--- a/flac-config.cmake.in
+++ b/flac-config.cmake.in
@@ -7,3 +7,12 @@ if(@OGG_FOUND@)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/targets.cmake")
+
+if(TARGET FLAC::FLAC)
+    set(FLAC_FLAC_FOUND 1)
+endif()
+if(TARGET FLAC::FLAC++)
+    set(FLAC_FLAC++_FOUND 1)
+endif()
+
+check_required_components(FLAC)


### PR DESCRIPTION
I finally figured how it works so implemented it for FLAC.

Usage:

```cmake
find_package(FLAC REQUIRED COMPONENTS FLAC++)
```

This fails with error:

```cmake
find_package(FLAC REQUIRED COMPONENTS foo)
```

This works but FLAC_FOUND is set to FALSE.

```cmake
find_package(FLAC OPTIONAL_COMPONENTS FLAC)
```

`FLAC_FLAC_FOUND` and `FLAC_FLAC++_FOUND` are the options to test you need libraries presence.

Simple mode `find_package(FLAC)` still works of course.